### PR TITLE
Refactor assembler addressing mode detection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod cpu;
+pub mod debugger;
+pub mod loader;
+pub mod memory;
+pub mod op_code;
+
+pub use cpu::CPU;
+pub use memory::Memory;

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,17 +1,115 @@
-//use crate::memory::Memory;
-//use crate::cpu::CPU;
-
 use std::collections::HashMap;
 use std::fs;
-//use std::io;
+use std::io;
 use std::path::Path;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum AddressingMode {
+    Implied,
+    Immediate,
+    ZeroPage,
+    Absolute,
+    Relative,
+    Accumulator,
+    Indirect,
+}
 
+fn operand_size(mode: AddressingMode) -> usize {
+    match mode {
+        AddressingMode::Implied | AddressingMode::Accumulator => 0,
+        AddressingMode::Immediate | AddressingMode::ZeroPage | AddressingMode::Relative => 1,
+        AddressingMode::Absolute | AddressingMode::Indirect => 2,
+    }
+}
 
-pub fn read_file (file_path: String) -> String {
+fn is_branch_instruction(mnemonic: &str) -> bool {
+    matches!(
+        mnemonic,
+        "BCC" | "BCS" | "BEQ" | "BMI" | "BNE" | "BPL" | "BVC" | "BVS"
+    )
+}
+
+fn parse_operand(
+    mnemonic: &str,
+    operand: Option<&str>,
+) -> Result<(AddressingMode, Vec<u8>), Box<dyn std::error::Error>> {
+    match operand {
+        None => Ok((AddressingMode::Implied, Vec::new())),
+        Some(raw_operand) => {
+            let operand = raw_operand.trim().trim_end_matches(',');
+
+            if operand.is_empty() {
+                return Ok((AddressingMode::Implied, Vec::new()));
+            }
+
+            if operand.starts_with('#') {
+                let value_str = operand
+                    .trim_start_matches('#')
+                    .trim_start_matches('$')
+                    .trim();
+                let value = u8::from_str_radix(value_str, 16).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("Invalid immediate operand: {}", operand),
+                    )
+                })?;
+                return Ok((AddressingMode::Immediate, vec![value]));
+            }
+
+            if operand.eq_ignore_ascii_case("A") {
+                return Ok((AddressingMode::Accumulator, Vec::new()));
+            }
+
+            if operand.starts_with("($") && operand.ends_with(')') {
+                let value_str = &operand[2..operand.len() - 1];
+                let value = u16::from_str_radix(value_str, 16).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("Invalid indirect operand: {}", operand),
+                    )
+                })?;
+                return Ok((
+                    AddressingMode::Indirect,
+                    vec![(value & 0xFF) as u8, (value >> 8) as u8],
+                ));
+            }
+
+            if operand.starts_with('$') {
+                let value_str = operand.trim_start_matches('$');
+                let value = u16::from_str_radix(value_str, 16).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("Invalid operand: {}", operand),
+                    )
+                })?;
+
+                if is_branch_instruction(mnemonic) {
+                    return Ok((AddressingMode::Relative, vec![value as u8]));
+                }
+
+                if value_str.len() <= 2 {
+                    return Ok((AddressingMode::ZeroPage, vec![value as u8]));
+                }
+
+                return Ok((
+                    AddressingMode::Absolute,
+                    vec![(value & 0xFF) as u8, (value >> 8) as u8],
+                ));
+            }
+
+            Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Unsupported operand format: {}", operand),
+            )
+            .into())
+        }
+    }
+}
+
+pub fn read_file(file_path: String) -> String {
     let path = Path::new(&file_path);
 
-    if let Some(ext) = path.extension () {
+    if let Some(ext) = path.extension() {
         if ext == "asm" {
             println!("File is an ASM file");
         } else {
@@ -21,152 +119,152 @@ pub fn read_file (file_path: String) -> String {
         println!("File has no extension");
     }
 
-
-    let contents = fs::read_to_string(path)
-        .expect("Should have read the file, it exists");
+    let contents = fs::read_to_string(path).expect("Should have read the file, it exists");
 
     contents
 }
 
-
 pub fn assemble(file_path: String) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let opcode_table: HashMap<&str, (u8, usize)> = [
+    let opcode_entries = [
         // Load and Store Instructions
-        ("LDA", (0xA9, 1)), // Immediate
-        ("LDA", (0xA5, 1)), // Zero Page
-        ("LDA", (0xAD, 2)), // Absolute
-        ("STA", (0x85, 1)), // Zero Page
-        ("STA", (0x8D, 2)), // Absolute
-        ("LDX", (0xA2, 1)), // Immediate
-        ("LDX", (0xA6, 1)), // Zero Page
-        ("LDX", (0xAE, 2)), // Absolute
-        ("STX", (0x86, 1)), // Zero Page
-        ("STX", (0x8E, 2)), // Absolute
-        ("LDY", (0xA0, 1)), // Immediate
-        ("LDY", (0xA4, 1)), // Zero Page
-        ("LDY", (0xAC, 2)), // Absolute
-        ("STY", (0x84, 1)), // Zero Page
-        ("STY", (0x8C, 2)), // Absolute
-
+        ("LDA", AddressingMode::Immediate, 0xA9),
+        ("LDA", AddressingMode::ZeroPage, 0xA5),
+        ("LDA", AddressingMode::Absolute, 0xAD),
+        ("STA", AddressingMode::ZeroPage, 0x85),
+        ("STA", AddressingMode::Absolute, 0x8D),
+        ("LDX", AddressingMode::Immediate, 0xA2),
+        ("LDX", AddressingMode::ZeroPage, 0xA6),
+        ("LDX", AddressingMode::Absolute, 0xAE),
+        ("STX", AddressingMode::ZeroPage, 0x86),
+        ("STX", AddressingMode::Absolute, 0x8E),
+        ("LDY", AddressingMode::Immediate, 0xA0),
+        ("LDY", AddressingMode::ZeroPage, 0xA4),
+        ("LDY", AddressingMode::Absolute, 0xAC),
+        ("STY", AddressingMode::ZeroPage, 0x84),
+        ("STY", AddressingMode::Absolute, 0x8C),
         // Transfer Instructions
-        ("TAX", (0xAA, 0)), // Transfer A to X
-        ("TXA", (0x8A, 0)), // Transfer X to A
-        ("TAY", (0xA8, 0)), // Transfer A to Y
-        ("TYA", (0x98, 0)), // Transfer Y to A
-
+        ("TAX", AddressingMode::Implied, 0xAA),
+        ("TXA", AddressingMode::Implied, 0x8A),
+        ("TAY", AddressingMode::Implied, 0xA8),
+        ("TYA", AddressingMode::Implied, 0x98),
         // Stack Instructions
-        ("TSX", (0xBA, 0)), // Transfer Stack Pointer to X
-        ("TXS", (0x9A, 0)), // Transfer X to Stack Pointer
-        ("PHA", (0x48, 0)), // Push A
-        ("PLA", (0x68, 0)), // Pull A
-        ("PHP", (0x08, 0)), // Push Processor Status
-        ("PLP", (0x28, 0)), // Pull Processor Status
-
+        ("TSX", AddressingMode::Implied, 0xBA),
+        ("TXS", AddressingMode::Implied, 0x9A),
+        ("PHA", AddressingMode::Implied, 0x48),
+        ("PLA", AddressingMode::Implied, 0x68),
+        ("PHP", AddressingMode::Implied, 0x08),
+        ("PLP", AddressingMode::Implied, 0x28),
         // Arithmetic and Logic Instructions
-        ("ADC", (0x69, 1)), // Immediate
-        ("ADC", (0x65, 1)), // Zero Page
-        ("ADC", (0x6D, 2)), // Absolute
-        ("SBC", (0xE9, 1)), // Immediate
-        ("SBC", (0xE5, 1)), // Zero Page
-        ("SBC", (0xED, 2)), // Absolute
-        ("CMP", (0xC9, 1)), // Immediate
-        ("CMP", (0xC5, 1)), // Zero Page
-        ("CMP", (0xCD, 2)), // Absolute
-        ("CPX", (0xE0, 1)), // Immediate
-        ("CPX", (0xE4, 1)), // Zero Page
-        ("CPX", (0xEC, 2)), // Absolute
-        ("CPY", (0xC0, 1)), // Immediate
-        ("CPY", (0xC4, 1)), // Zero Page
-        ("CPY", (0xCC, 2)), // Absolute
-
+        ("ADC", AddressingMode::Immediate, 0x69),
+        ("ADC", AddressingMode::ZeroPage, 0x65),
+        ("ADC", AddressingMode::Absolute, 0x6D),
+        ("SBC", AddressingMode::Immediate, 0xE9),
+        ("SBC", AddressingMode::ZeroPage, 0xE5),
+        ("SBC", AddressingMode::Absolute, 0xED),
+        ("CMP", AddressingMode::Immediate, 0xC9),
+        ("CMP", AddressingMode::ZeroPage, 0xC5),
+        ("CMP", AddressingMode::Absolute, 0xCD),
+        ("CPX", AddressingMode::Immediate, 0xE0),
+        ("CPX", AddressingMode::ZeroPage, 0xE4),
+        ("CPX", AddressingMode::Absolute, 0xEC),
+        ("CPY", AddressingMode::Immediate, 0xC0),
+        ("CPY", AddressingMode::ZeroPage, 0xC4),
+        ("CPY", AddressingMode::Absolute, 0xCC),
         // Increment and Decrement Instructions
-        ("INC", (0xE6, 1)), // Zero Page
-        ("INC", (0xEE, 2)), // Absolute
-        ("INX", (0xE8, 0)), // Increment X
-        ("INY", (0xC8, 0)), // Increment Y
-        ("DEC", (0xC6, 1)), // Zero Page
-        ("DEC", (0xCE, 2)), // Absolute
-        ("DEX", (0xCA, 0)), // Decrement X
-        ("DEY", (0x88, 0)), // Decrement Y
-
+        ("INC", AddressingMode::ZeroPage, 0xE6),
+        ("INC", AddressingMode::Absolute, 0xEE),
+        ("INX", AddressingMode::Implied, 0xE8),
+        ("INY", AddressingMode::Implied, 0xC8),
+        ("DEC", AddressingMode::ZeroPage, 0xC6),
+        ("DEC", AddressingMode::Absolute, 0xCE),
+        ("DEX", AddressingMode::Implied, 0xCA),
+        ("DEY", AddressingMode::Implied, 0x88),
         // Shift and Rotate Instructions
-        ("ASL", (0x0A, 0)), // Accumulator
-        ("ASL", (0x06, 1)), // Zero Page
-        ("ASL", (0x0E, 2)), // Absolute
-        ("LSR", (0x4A, 0)), // Accumulator
-        ("LSR", (0x46, 1)), // Zero Page
-        ("LSR", (0x4E, 2)), // Absolute
-        ("ROL", (0x2A, 0)), // Accumulator
-        ("ROL", (0x26, 1)), // Zero Page
-        ("ROL", (0x2E, 2)), // Absolute
-        ("ROR", (0x6A, 0)), // Accumulator
-        ("ROR", (0x66, 1)), // Zero Page
-        ("ROR", (0x6E, 2)), // Absolute
-
+        ("ASL", AddressingMode::Accumulator, 0x0A),
+        ("ASL", AddressingMode::ZeroPage, 0x06),
+        ("ASL", AddressingMode::Absolute, 0x0E),
+        ("LSR", AddressingMode::Accumulator, 0x4A),
+        ("LSR", AddressingMode::ZeroPage, 0x46),
+        ("LSR", AddressingMode::Absolute, 0x4E),
+        ("ROL", AddressingMode::Accumulator, 0x2A),
+        ("ROL", AddressingMode::ZeroPage, 0x26),
+        ("ROL", AddressingMode::Absolute, 0x2E),
+        ("ROR", AddressingMode::Accumulator, 0x6A),
+        ("ROR", AddressingMode::ZeroPage, 0x66),
+        ("ROR", AddressingMode::Absolute, 0x6E),
         // Jump and Branch Instructions
-        ("JMP", (0x4C, 2)), // Absolute
-        ("JMP", (0x6C, 2)), // Indirect
-        ("JSR", (0x20, 2)), // Jump to Subroutine
-        ("RTS", (0x60, 0)), // Return from Subroutine
-        ("RTI", (0x40, 0)), // Return from Interrupt
-        ("BCC", (0x90, 1)), // Branch if Carry Clear
-        ("BCS", (0xB0, 1)), // Branch if Carry Set
-        ("BEQ", (0xF0, 1)), // Branch if Equal
-        ("BMI", (0x30, 1)), // Branch if Minus
-        ("BNE", (0xD0, 1)), // Branch if Not Equal
-        ("BPL", (0x10, 1)), // Branch if Plus
-        ("BVC", (0x50, 1)), // Branch if Overflow Clear
-        ("BVS", (0x70, 1)), // Branch if Overflow Set
-
+        ("JMP", AddressingMode::Absolute, 0x4C),
+        ("JMP", AddressingMode::Indirect, 0x6C),
+        ("JSR", AddressingMode::Absolute, 0x20),
+        ("RTS", AddressingMode::Implied, 0x60),
+        ("RTI", AddressingMode::Implied, 0x40),
+        ("BCC", AddressingMode::Relative, 0x90),
+        ("BCS", AddressingMode::Relative, 0xB0),
+        ("BEQ", AddressingMode::Relative, 0xF0),
+        ("BMI", AddressingMode::Relative, 0x30),
+        ("BNE", AddressingMode::Relative, 0xD0),
+        ("BPL", AddressingMode::Relative, 0x10),
+        ("BVC", AddressingMode::Relative, 0x50),
+        ("BVS", AddressingMode::Relative, 0x70),
         // Flag Instructions
-        ("CLC", (0x18, 0)), // Clear Carry
-        ("SEC", (0x38, 0)), // Set Carry
-        ("CLI", (0x58, 0)), // Clear Interrupt
-        ("SEI", (0x78, 0)), // Set Interrupt
-        ("CLV", (0xB8, 0)), // Clear Overflow
-        ("CLD", (0xD8, 0)), // Clear Decimal
-        ("SED", (0xF8, 0)), // Set Decimal
-
+        ("CLC", AddressingMode::Implied, 0x18),
+        ("SEC", AddressingMode::Implied, 0x38),
+        ("CLI", AddressingMode::Implied, 0x58),
+        ("SEI", AddressingMode::Implied, 0x78),
+        ("CLV", AddressingMode::Implied, 0xB8),
+        ("CLD", AddressingMode::Implied, 0xD8),
+        ("SED", AddressingMode::Implied, 0xF8),
         // No Operation
-        ("NOP", (0xEA, 0)), // No operation
-    ].iter().cloned().collect();
+        ("NOP", AddressingMode::Implied, 0xEA),
+    ];
+
+    let mut opcode_table: HashMap<(String, AddressingMode), u8> = HashMap::new();
+    for (mnemonic, mode, opcode) in opcode_entries.into_iter() {
+        opcode_table.insert((mnemonic.to_string(), mode), opcode);
+    }
 
     let mut program = Vec::new();
     let contents = read_file(file_path);
 
     for line in contents.lines() {
-        // Remove comments and trim whitespace
         let line = line.split(';').next().unwrap().trim();
         if line.is_empty() {
-            continue; // Skip empty lines
+            continue;
         }
 
-        let mut parts = line.split_whitespace();
+        let mut parts = line.splitn(2, |c: char| c.is_whitespace());
         if let Some(instruction) = parts.next() {
-            if let Some(&(opcode, operand_size)) = opcode_table.get(instruction) {
-                program.push(opcode); // Add the opcode to the program
+            let mnemonic = instruction.to_ascii_uppercase();
+            let operand_str = parts.next().map(str::trim);
+            let (addressing_mode, operand_bytes) = parse_operand(&mnemonic, operand_str)?;
 
-                for operand in parts.take(operand_size) {
-                    let operand = operand.trim_start_matches(&['#', '$'][..]);
-                    let value = if operand_size == 1 {
-                        u8::from_str_radix(operand, 16)
-                            .expect(&format!("Invalid operand: {}", operand))
-                            as u16
-                    } else {
-                        u16::from_str_radix(operand, 16)
-                            .expect(&format!("Invalid operand: {}", operand))
-                    };
+            let expected_operand_size = operand_size(addressing_mode);
+            if operand_bytes.len() != expected_operand_size {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "Operand width mismatch for {} {:?}: expected {} bytes, got {} bytes",
+                        mnemonic,
+                        addressing_mode,
+                        expected_operand_size,
+                        operand_bytes.len()
+                    ),
+                )
+                .into());
+            }
 
-                    // Push the operand bytes (little-endian for 16-bit)
-                    if operand_size == 2 {
-                        program.push((value & 0xFF) as u8); // Low byte
-                        program.push((value >> 8) as u8);  // High byte
-                    } else {
-                        program.push(value as u8); // Single byte
-                    }
-                }
+            if let Some(&opcode) = opcode_table.get(&(mnemonic.clone(), addressing_mode)) {
+                program.push(opcode);
+                program.extend_from_slice(&operand_bytes);
             } else {
-                panic!("Unknown instruction: {}", instruction);
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "Unknown instruction or addressing mode: {} {:?}",
+                        mnemonic, addressing_mode
+                    ),
+                )
+                .into());
             }
         }
     }

--- a/tests/assembler_tests.rs
+++ b/tests/assembler_tests.rs
@@ -1,0 +1,34 @@
+use rust_6502_emulator::loader::assemble;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn write_asm(contents: &str) -> PathBuf {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("assembler_test_{}.asm", timestamp));
+    fs::write(&path, contents).expect("Failed to write assembly file");
+    path
+}
+
+#[test]
+fn assemble_handles_lda_addressing_modes() {
+    let path = write_asm("LDA #$01\nLDA $10\nLDA $1234\n");
+
+    let program = assemble(path.to_string_lossy().into_owned()).expect("Failed to assemble");
+    fs::remove_file(&path).ok();
+
+    assert_eq!(program, vec![0xA9, 0x01, 0xA5, 0x10, 0xAD, 0x34, 0x12]);
+}
+
+#[test]
+fn assemble_handles_sta_addressing_modes() {
+    let path = write_asm("STA $20\nSTA $5678\n");
+
+    let program = assemble(path.to_string_lossy().into_owned()).expect("Failed to assemble");
+    fs::remove_file(&path).ok();
+
+    assert_eq!(program, vec![0x85, 0x20, 0x8D, 0x78, 0x56]);
+}


### PR DESCRIPTION
## Summary
- update the assembler to key opcodes by mnemonic and addressing mode and parse operands to choose widths
- expose the crate modules from lib.rs so integration tests can call into the assembler
- add assembler integration tests for LDA and STA immediate, zero-page, and absolute addressing

## Testing
- cargo test --test assembler_tests

------
https://chatgpt.com/codex/tasks/task_e_68d5eeb65a0483209c7c1f561f5c0f13