### PR TITLE
Make load_program accept lifetime-bearing source

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 pub mod cpu;
 pub mod debugger;
 pub mod loader;
@@ -6,3 +8,15 @@ pub mod op_code;
 
 pub use cpu::CPU;
 pub use memory::Memory;
+
+pub type ProgramSource<'a> = Cow<'a, [u8]>;
+
+pub fn load_program<'a>(cpu: &mut CPU, memory: &mut Memory, source: ProgramSource<'a>) {
+    const START_ADDR: u16 = 0x0600;
+
+    for (offset, &byte) in source.iter().enumerate() {
+        memory.write(START_ADDR + offset as u16, byte);
+    }
+
+    cpu.pc = START_ADDR;
+}


### PR DESCRIPTION
## Summary
- add a `ProgramSource<'a>` type alias in `lib.rs` backed by `Cow<'a, [u8]>`
- update `load_program` to accept lifetime-bearing program sources and copy bytes into memory

## Testing
- `cargo test` *(fails: missing supporting test modules in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f35998088320827a8c7391020a56